### PR TITLE
Add docstrings to dsupdt.py and pg_updt.py; improve dsupdt.usg

### DIFF
--- a/src/rda_python_dsupdt/dsupdt.py
+++ b/src/rda_python_dsupdt/dsupdt.py
@@ -21,7 +21,22 @@ from .pg_updt import PgUpdt
 from rda_python_common.pg_split import PgSplit
 
 class DsUpdt(PgUpdt, PgSplit):
+   """Main application class for the dsupdt dataset-update utility.
+
+   Extends PgUpdt (update control / DB utilities) and PgSplit (multiprocessing
+   support) to implement the full dataset-update workflow:
+
+   * Downloading remote files via configurable commands (wget, ncftpget, rsync, …)
+   * Building or converting local files from downloaded sources
+   * Archiving local files to RDA web, Saved, or Quasar storage via dsarch
+   * Managing update control records (dcupdt), local file records (dlupdt), and
+     remote file records (drupdt) in RDADB
+   * Checking dataset update status and sending notification emails
+   * Scheduling and dispatching child processes for parallel updates
+   """
+
    def __init__(self):
+      """Initialize DsUpdt instance state and call parent __init__."""
       super().__init__()  # initialize parent class
       self.TEMPINFO = {}
       self.TOPMSG = self.SUBJECT = self.ACTSTR = None
@@ -32,6 +47,11 @@ class DsUpdt(PgUpdt, PgSplit):
 
    # main function to run dsupdt
    def read_parameters(self):
+         """Parse and validate command-line arguments for the dsupdt action.
+
+         Sets the help path, calls parsing_input() to populate self.params, and
+         then check_enough_options() to ensure mandatory options are present.
+         """
          self.set_help_path(__file__)
          aname = 'dsupdt'
          self.parsing_input(aname)
@@ -39,6 +59,14 @@ class DsUpdt(PgUpdt, PgSplit):
 
    # start actions of dsupdt
    def start_actions(self):
+      """Dispatch and execute the primary dsupdt action requested on the command line.
+
+      Routes to the appropriate method based on self.PGOPT['ACTS'] / self.PGOPT['CACT']:
+      CU (CheckUpdate), DL (Delete), GA/GC/GL/GR (Get*), SC/SL/SR/SA (Set*),
+      UF (UpdateFile), UL (UnLock), and PC (ProcessControls).  After the action
+      completes, builds and sends an email summary if required, records dscheck
+      status, and logs the end time.
+      """
       if self.PGOPT['ACTS']&self.OPTS['CU'][0]:
          if 'CI' in self.params:
             if self.cache_update_control(self.params['CI'][0], 1):
@@ -120,6 +148,11 @@ class DsUpdt(PgUpdt, PgSplit):
 
    # delete update control records for given dsid and control indices
    def delete_control_info(self):
+      """Delete dcupdt control records for the control indices in self.params['CI'].
+
+      Also clears the cindex foreign key on any associated dlupdt records.
+      Acquires a lock on each control record before deleting it.
+      """
       s = 's' if self.ALLCNT > 1 else ''
       self.pglog("Delete {} update control record{} ...".format(self.ALLCNT, s), self.WARNLG)
       delcnt = modcnt = 0
@@ -136,6 +169,11 @@ class DsUpdt(PgUpdt, PgSplit):
 
    # delete local files for given dsid and locfile indices
    def delete_local_info(self):
+      """Delete dlupdt local file records for the indices in self.params['LI'].
+
+      Cascades to delete any associated drupdt remote file records before
+      removing each dlupdt row.  Acquires a lock before each deletion.
+      """
       s = 's' if self.ALLCNT > 1 else ''
       self.pglog("Delete {} Locfile record{} ...".format(self.ALLCNT, s), self.WARNLG)
       dcnt = delcnt = 0
@@ -156,6 +194,10 @@ class DsUpdt(PgUpdt, PgSplit):
 
    # delete update remote files for given dsid and remote files/locfile indices
    def delete_remote_info(self):
+      """Delete drupdt remote file records for the indices/names in self.params.
+
+      Matches rows by lindex + remotefile (and optionally dindex via -DO).
+      """
       s = 's' if self.ALLCNT > 1 else ''
       self.pglog("Delete {} remote file record{} ...".format(self.ALLCNT, s), self.WARNLG)
       self.validate_multiple_options(self.ALLCNT, ["LI", "DO"])
@@ -168,6 +210,11 @@ class DsUpdt(PgUpdt, PgSplit):
 
    # get update control information
    def get_control_info(self):
+      """Retrieve and print dcupdt update control records for the current dataset.
+
+      Applies any field-name (-FN) and order (-ON) filters, then formats and
+      writes the results to self.OUTPUT.
+      """
       tname = "dcupdt"
       hash = self.TBLHASH[tname]
       self.pglog("Get update control info of {} from RDADB ...".format(self.params['DS']), self.WARNLG)
@@ -190,6 +237,11 @@ class DsUpdt(PgUpdt, PgSplit):
 
    # get local file update information
    def get_local_info(self):
+      """Retrieve and print dlupdt local file records for the current dataset.
+
+      Applies any field-name (-FN) and order (-ON) filters, then formats and
+      writes the results to self.OUTPUT.
+      """
       tname = "dlupdt"
       hash = self.TBLHASH[tname]
       self.pglog("Get local file update info of {} from RDADB ...".format(self.params['DS']), self.WARNLG)
@@ -214,6 +266,11 @@ class DsUpdt(PgUpdt, PgSplit):
 
    # get remote file update information
    def get_remote_info(self):
+      """Retrieve and print drupdt remote file records for the current dataset.
+
+      Applies any field-name (-FN) and order (-ON) filters, then formats and
+      writes the results to self.OUTPUT.
+      """
       tname = "drupdt"
       hash = self.TBLHASH[tname]
       self.pglog("Get remote file update info of {} from RDADB ...".format(self.params['DS']), self.WARNLG)
@@ -238,6 +295,12 @@ class DsUpdt(PgUpdt, PgSplit):
 
    # add or modify update control information
    def set_control_info(self):
+      """Insert or update dcupdt control records for the indices in self.params['CI'].
+
+      For each index: if > 0, locks and updates the existing record; if 0 (with
+      -NC), inserts a new record.  Validates parent index and action name before
+      writing.
+      """
       tname = 'dcupdt'
       s = 's' if self.ALLCNT > 1 else ''
       self.pglog("Set {} update control record{} ...".format(self.ALLCNT, s), self.WARNLG)
@@ -275,6 +338,12 @@ class DsUpdt(PgUpdt, PgSplit):
 
    # add or modify local file update information
    def set_local_info(self):
+      """Insert or update dlupdt local file records for the indices in self.params['LI'].
+
+      For each index: if > 0, locks and updates; if 0 (with -NL), inserts a new
+      record.  Validates control index and action name; assigns the next
+      execorder for new records.
+      """
       tname = 'dlupdt'
       s = 's' if self.ALLCNT > 1 else ''
       self.pglog("Set {} local file record{} ...".format(self.ALLCNT, s), self.WARNLG)
@@ -316,6 +385,11 @@ class DsUpdt(PgUpdt, PgSplit):
 
    # add or modify remote file update information
    def set_remote_info(self):
+      """Insert or update drupdt remote file records for the pairs in self.params.
+
+      Matches existing rows by lindex + remotefile + dindex.  Validates that the
+      referenced lindex exists in dlupdt before inserting a new record.
+      """
       tname = 'drupdt'
       s = 's' if self.ALLCNT > 1 else ''
       self.pglog("Set {} update remote file{} ...".format(self.ALLCNT, s), self.WARNLG)
@@ -343,6 +417,11 @@ class DsUpdt(PgUpdt, PgSplit):
 
    # unlock update records for given locfile indices
    def unlock_update_info(self):
+      """Unlock dlupdt records locked by dead or stale processes.
+
+      For each lindex in self.params['LI']: attempts a normal unlock; if that
+      fails and the locking host appears to be down, forces the unlock.
+      """
       s = 's' if self.ALLCNT > 1 else ''
       self.pglog("Unlock {} update locfile{} ...".format(self.ALLCNT, s), self.WARNLG)
       modcnt = 0
@@ -366,6 +445,11 @@ class DsUpdt(PgUpdt, PgSplit):
 
    # unlock update control records for given locfile indices
    def unlock_control_info(self):
+      """Unlock dcupdt control records locked by dead or stale processes.
+
+      For each cindex in self.params['CI']: attempts a normal unlock; if that
+      fails and the locking host appears to be down, forces the unlock.
+      """
       s = 's' if self.ALLCNT > 1 else ''
       self.pglog("Unlock {} update control{} ...".format(self.ALLCNT, s), self.WARNLG)
       modcnt = 0
@@ -388,6 +472,14 @@ class DsUpdt(PgUpdt, PgSplit):
 
    # get update info of local and remote files owned by login name
    def get_update_info(self):
+      """Retrieve and print update records (control, local, and/or remote) for one
+      or more datasets.
+
+      When no -DS is given, determines the applicable dataset list from dlupdt
+      filtered by the login name or other conditions.  Iterates over each
+      dataset and calls get_control_info(), get_local_info(), and/or
+      get_remote_info() according to the action bitmask.
+      """
       if 'DS' in self.params:
          dsids = {'dsid': [self.params['DS']]}
          dscnt = 1
@@ -422,6 +514,15 @@ class DsUpdt(PgUpdt, PgSplit):
 
    # gather due datasets for data update
    def dataset_update(self):
+      """Orchestrate the full data-update cycle across all due datasets.
+
+      Determines which datasets and local file records are due for update,
+      then calls file_update() for each one.  Handles multiprocessing via
+      child processes when self.PGSIG['MPROC'] > 1.  After all files are
+      processed, renews internal version numbers if any files were rearchived,
+      refreshes metadata, builds the email subject/top-message, and resets the
+      control time when a control record was active.
+      """
       actcnd = "specialist = '{}'".format(self.params['LN'])
       if self.PGOPT['ACTS']&self.OPTS['AF'][0]: actcnd += " AND action IN ('AW', 'AS', 'AQ')"
       (self.PGOPT['CURDATE'], self.PGOPT['CURHOUR']) = self.curdatehour()
@@ -589,6 +690,14 @@ class DsUpdt(PgUpdt, PgSplit):
 
    # renew internal version number for given dataset
    def renew_internal_version(self, dsid, vcnt):
+      """Invoke dsarch to bump the internal version number after rearchiving files.
+
+      Runs ``dsarch <dsid> SV -NV`` and logs the new version number and DOI.
+
+      Args:
+         dsid (str): Dataset ID.
+         vcnt (int): Number of files that were rearchived (used for log message).
+      """
       s = 's' if vcnt > 1 else ''
       cmd = "dsarch {} SV -NV -DE '{} Data file{} rearchived'".format(dsid, vcnt, s)
       if self.pgsystem(cmd, self.PGOPT['emerol'], 5):  # 1 + 4
@@ -601,6 +710,19 @@ class DsUpdt(PgUpdt, PgSplit):
 
    # cach the total count of files to be archived
    def count_caching(self, locrec, locinfo):
+      """Estimate the total number of files that will be archived for *locrec*.
+
+      Used during dscheck pre-counting passes to report expected work.
+      Multiplies the number of serial-pattern expansions by the number of
+      update periods in the temporal info.
+
+      Args:
+         locrec (dict): Local file DB record.
+         locinfo (str): Log label.
+
+      Returns:
+         int: Estimated file count.
+      """
       files = self.expand_serial_pattern(locrec['locfile'])
       scnt = len(files) if files else 1
       if self.ALLCNT > 1:
@@ -612,6 +734,28 @@ class DsUpdt(PgUpdt, PgSplit):
 
    # gather/archive due data file for update of each local file
    def file_update(self, locrec, logact, caching = 0):
+      """Run the download / build / archive pipeline for one local file record.
+
+      For each update period derived from get_tempinfo():
+        1. Resolves local and remote filenames.
+        2. Downloads remote files via download_remote_files() (DR/PB/UF).
+        3. Builds the local file via build_local_file() (BL/PB/UF).
+        4. Archives the local file via archive_data_file() (AF/UF).
+        5. Cleans working copies via clean_files() (CF/UF).
+        6. Advances the stored end-date via reset_update_time().
+
+      When *caching* is set, returns only the expected file count without
+      performing any real work (used for dscheck pre-counting).
+
+      Args:
+         locrec (dict): dlupdt local file record.
+         logact (int): Log action bitmask for progress messages.
+         caching (int): If non-zero, return the expected count without acting.
+
+      Returns:
+         int: Number of successfully processed update periods (or count when
+         caching), 0 on lock failure or no work, negative on fatal error.
+      """
       lfile = locrec['locfile']
       endonly = retcnt = 0
       lindex = locrec['lindex']
@@ -841,6 +985,15 @@ class DsUpdt(PgUpdt, PgSplit):
 
    # refresh the gathered metadata with speed up option -R and -S
    def refresh_metadata(self, dsid):
+      """Invoke the search-metadata command to refresh web-table indices after archiving.
+
+      Called periodically (every RSMAX files) during archiving when the -RS
+      (refresh-search) option is active.  Flushes the accumulated wtidx set
+      after running the command.
+
+      Args:
+         dsid (str): Dataset ID to refresh.
+      """
       if self.sm is None: self.sm = self.valid_command(self.PGOPT['scm'], self.PGOPT['emlerr'])
       if self.PGOPT['wtidx']:
          if self.sm:
@@ -852,8 +1005,31 @@ class DsUpdt(PgUpdt, PgSplit):
                   self.pgsystem("{}w {}".format(sx, tidx), self.PGOPT['emllog'], 1029)  # 1+4+1024
          self.PGOPT['wtidx'] = {}
 
-   # retrieve remote files# act: > 0 - create filenames and get data files physically; 0 - create filenames only
+   # retrieve remote files
+   # act: > 0 - create filenames and get data files physically; 0 - create filenames only
    def download_remote_files(self, rmtrec, lfile, linfo, locrec, locinfo, tempinfo, act = 0):
+      """Download remote files described by *rmtrec* to the local working directory.
+
+      Resolves remote and server filenames, then for each file: checks whether a
+      local copy already exists and is current; if not, runs the download command
+      and validates the result.  Processes remote file via *processremote* command
+      when specified.  Returns the list of successfully obtained local filenames
+      (or None on failure).
+
+      Args:
+         rmtrec (dict): drupdt remote file record (remotefile, serverfile, download,
+            tinterval, begintime, endtime).
+         lfile (str): Target local filename.
+         linfo (dict | None): Existing local file info from check_local_file().
+         locrec (dict): dlupdt local file record (options, action, etc.).
+         locinfo (str): Log label.
+         tempinfo (dict): Temporal info dict for the current update period.
+         act (int): If > 0, physically retrieve files; if 0, only build the
+            filename list (used for status checking).
+
+      Returns:
+         list[str] | None: List of downloaded local filenames, or None on error.
+      """
       emlsum = self.PGOPT['emlsum'] if self.PGOPT['CACT'] == "DR" else self.PGOPT['emllog']
       rfile = rmtrec['remotefile']
       rmtinfo = locinfo
@@ -1169,6 +1345,29 @@ class DsUpdt(PgUpdt, PgSplit):
 
    # build up local files
    def build_local_file(self, rfiles, lfile, linfo, locrec, tempinfo, lcnt, l):
+      """Build a local file from one or more downloaded remote files.
+
+      Supports three build strategies:
+        1. Explicit build command (buildcmd): runs the command directly.
+        2. Executable local file spec (``!command``): runs the command to get the name.
+        3. Automatic: compresses/converts individual files and then tars them, or
+           directly renames/converts a single remote file.
+
+      Creates parent directories as needed, backs up any existing local file,
+      and restores the backup on failure.
+
+      Args:
+         rfiles (list[str]): Downloaded remote filenames.
+         lfile (str): Target local filename.
+         linfo (dict | None): Existing local file info.
+         locrec (dict): dlupdt record (options, buildcmd, action, etc.).
+         tempinfo (dict): Temporal info (edate, ehour, FQ, blcmd, AQ).
+         lcnt (int): Total number of local files in the serial expansion.
+         l (int): Index of the current local file within the serial expansion.
+
+      Returns:
+         int: 1 on success, 0 on failure.
+      """
       emlsum = self.PGOPT['emlsum'] if (self.PGOPT['ACTS'] == self.OPTS['BL'][0]) else self.PGOPT['emllog']
       if lcnt > 1:
          rcnt = 1
@@ -1277,18 +1476,54 @@ class DsUpdt(PgUpdt, PgSplit):
 
    # append data type to options for given type name if not in options
    def append_data_type(self, tname, options):
+      """Append a default data-type flag to *options* if it is not already present.
+
+      Args:
+         tname (str): Option name key in self.DEFTYPES (e.g. 'WT', 'ST', 'QT').
+         options (str): Current dsarch options string.
+
+      Returns:
+         str: Updated options string.
+      """
       mp = r'(^|\s)-{}(\s|$)'.format(tname)
       if not re.search(mp, options, re.I): options += " -{} {}".format(tname, self.DEFTYPES[tname])
       return options
 
    # get data type from options for given type name, and default one if not in options
    def get_data_type(self, tname, options):
+      """Extract the data-type character from *options*, falling back to the default.
+
+      Args:
+         tname (str): Option name (e.g. 'WT', 'ST', 'QT').
+         options (str): dsarch options string.
+
+      Returns:
+         str: Single-character data type (e.g. 'D', 'P', 'B').
+      """
       mp = r'(^|\s)-{}\s+(\w)(\s|$)'.format(tname)
       ms = re.search(mp, options, re.I)
       return ms.group(2) if ms else self.DEFTYPES[tname]
 
    # archive a data file
    def archive_data_file(self, lfile, locrec, tempinfo, eidx):
+      """Archive a local data file by invoking dsarch with the appropriate options.
+
+      Skips archiving (returns -1) when the file is already archived and has not
+      changed.  Optionally moves the previous version-controlled file before
+      re-archiving.  Runs gatherxml to update metadata when the -GX option is set
+      in the local file's options field.
+
+      Args:
+         lfile (str): Local file path to archive.
+         locrec (dict): dlupdt record (action, options, archfile, note, etc.).
+         tempinfo (dict): Temporal info (edate, ehour, FQ, ainfo, RS, gotnew).
+         eidx (int): Index of the current update period (0-based); used to
+            suppress the re-archive hint on subsequent periods.
+
+      Returns:
+         int: Return code from dsarch (> 0 success, 0 or negative failure),
+         or -1 if archiving was skipped.
+      """
       growing = -1
       if tempinfo['ainfo']:
          ainfo = tempinfo['ainfo']
@@ -1375,6 +1610,14 @@ class DsUpdt(PgUpdt, PgSplit):
 
    # call gatherxml
    def call_gatherxml(self, gcmd):
+      """Run the gatherxml command to index a newly archived data file.
+
+      Redirects logging to gatherxml-specific log/err files and suppresses
+      known benign warning patterns from being treated as errors.
+
+      Args:
+         gcmd (str): Fully constructed gatherxml command string.
+      """
       logfile = self.PGLOG['LOGFILE']
       errfile = self.PGLOG['ERRFILE']
       self.PGLOG['LOGFILE'] = "gatherxml.log"
@@ -1388,6 +1631,21 @@ class DsUpdt(PgUpdt, PgSplit):
 
    # count files updated
    def count_update_files(self, oinfo, ninfo, success, rsopt):
+      """Compare pre- and post-archive file records and update per-type counters.
+
+      For each archive type (web, saved, quasar) in the new archive info,
+      increments the appropriate counter in self.PGOPT (udcnt, uncnt, uwcnt,
+      uscnt, qbcnt, qdcnt) and registers web-table indices for metadata refresh.
+
+      Args:
+         oinfo (dict | None): Archive info dict before the dsarch call.
+         ninfo (dict | None): Archive info dict after the dsarch call.
+         success (int): Non-zero if dsarch returned success.
+         rsopt (int): RS option value; 1 triggers web-table refresh tracking.
+
+      Returns:
+         str: Human-readable summary of what was (re-)archived, or empty string.
+      """
       nrecs = ninfo['types'] if ninfo else {}
       orecs = oinfo['types'] if oinfo else {}
       astrs = []
@@ -1440,9 +1698,27 @@ class DsUpdt(PgUpdt, PgSplit):
          astr += " of {} archfile{}".format(ninfo['archcnt'], s)
       return astr
 
-   # get the temporal info in local and remote file names and the possible values# between the break update and the current date
-   # BTW, change to working directory
+   # get the temporal info in local and remote file names and the possible values
+   # between the break update and the current date
    def get_tempinfo(self, locrec, locinfo, eidx = 0):
+      """Build the temporal-info dict for one or more update periods of *locrec*.
+
+      Resolves end date/hour, valid interval, age time, frequency, next-due
+      offset, and missing-remote flag from the local file record and current
+      parameters.  Computes the list of end dates/hours (ED/EH) that still
+      need to be updated up to the current date.
+
+      Args:
+         locrec (dict): dlupdt local file record (enddate, endhour, frequency,
+            validint, agetime, nextdue, missremote, options, action, etc.).
+         locinfo (str): Log label.
+         eidx (int): When > 0, index into self.params['ED'/'EH'] for explicit
+            multi-period invocations.
+
+      Returns:
+         dict | None: Temporal info dict with keys ED, EH, FQ, QU, VD, VH,
+         AT, NX, amiss, AQ, RS, etc.; or None / 0 on error / not-yet-due.
+      """
       # get data end date for update action
       edate = self.params['ED'][eidx] if ('ED' in self.params and self.params['ED'][eidx]) else locrec['enddate']
       if not edate: return self.pglog(locinfo + ": MISS End Data Date for local update", self.PGOPT['emlerr'])
@@ -1601,6 +1877,21 @@ class DsUpdt(PgUpdt, PgSplit):
 
    # get archived file info
    def file_archive_info(self, lfile, locrec, tempinfo):
+      """Query RDADB for the current archive status of *lfile*.
+
+      Looks up web files (wfile), saved files (sfile), or quasar backup files
+      (bfile) depending on the archive action.  Returns a dict with keys
+      archcnt, archived, present, vindex, types, note, and the matching file
+      path (wfile/sfile/bfile) when found.
+
+      Args:
+         lfile (str): Local filename whose archive record to look up.
+         locrec (dict): dlupdt record (action, options, archfile, gindex).
+         tempinfo (dict): Temporal info (edate, ehour, FQ, NX, ainfo).
+
+      Returns:
+         dict: Archive info dict (always returned, possibly with archived=0).
+      """
       if tempinfo['ainfo'] != None: return tempinfo['ainfo']
       edate = tempinfo['edate']
       ehour = tempinfo['ehour']
@@ -1711,9 +2002,25 @@ class DsUpdt(PgUpdt, PgSplit):
          self.pglog("{}: unknown archive action {}".format(lfile, act), self.PGOPT['extlog'])
       return ainfo   # always returns a hash reference for archiving info
 
-   # build up data note based on temporal info, keep the begin timestamp# for existing record; change end timestamp only if new data added
+   # build up data note based on temporal info, keep the begin timestamp
+   # for existing record; change end timestamp only if new data added
    # return None if no change for existing note
    def build_data_note(self, onote, lfile, locrec, tempinfo):
+      """Construct the data note string for the dsarch -DE option.
+
+      Preserves the begin-time from an existing note when two temporal patterns
+      are present.  Replaces temporal patterns with the current end date/hour.
+      Returns None when no change is needed for an existing note.
+
+      Args:
+         onote (str | None): Existing note text from the archive record.
+         lfile (str): Local filename (for log messages).
+         locrec (dict): dlupdt record (note field).
+         tempinfo (dict): Temporal info (edate, ehour, FQ, PD).
+
+      Returns:
+         str | None: New note string, or None if no update is required.
+      """
       note = locrec['note']
       if not note: return onote
       seps = self.params['PD']
@@ -1751,6 +2058,18 @@ class DsUpdt(PgUpdt, PgSplit):
 
    # get data file status info
    def file_status_info(self, lfile, rfile, tempinfo):
+      """Cache size, checksum, and modification timestamp of *lfile* before archiving.
+
+      Stores the results in self.PGOPT['fsize'], self.PGOPT['chksm'],
+      self.PGOPT['fdate'], and self.PGOPT['ftime'].  When -RE is active,
+      also advances tempinfo['edate'/'ehour'] to the file's actual data date.
+
+      Args:
+         lfile (str): Local file path to inspect.
+         rfile (str | None): Associated remote file path (used to get an
+            earlier modification timestamp if applicable).
+         tempinfo (dict): Temporal info dict (updated in place for -RE mode).
+      """
       # check and cache new data info
       finfo = self.check_local_file(lfile, 33, self.PGOPT['wrnlog'])   # 33 = 1 + 32
       if not finfo:
@@ -1788,8 +2107,23 @@ class DsUpdt(PgUpdt, PgSplit):
             tempinfo['edate'] = edate
             tempinfo['ehour'] = ehour
 
-   # check if a Server file is aged enough for download# return 1 if valid, 0 if not aged enough, -1 if cannot check
+   # check if a Server file is aged enough for download
+   # return 1 if valid, 0 if not aged enough, -1 if cannot check
    def check_agetime(self, dcmd, sfile, atime):
+      """Check whether a server file is old enough to be downloaded.
+
+      Compares the file's last-modified time plus the *atime* interval to the
+      current date/hour.  Returns 0 (skip) if the file is not yet aged enough,
+      1 if it is ready, or a negative code on error.
+
+      Args:
+         dcmd (str): Download command used to locate the server file.
+         sfile (str): Server filename for log messages.
+         atime (list): Age-time interval array from get_control_time().
+
+      Returns:
+         int: 1 if aged enough, 0 if not yet ready, negative on error.
+      """
       info = self.check_server_file(dcmd, 1)
       if not info:
          sact = self.get_download_action(dcmd)
@@ -1812,9 +2146,26 @@ class DsUpdt(PgUpdt, PgSplit):
                       "but NOT aged enough for retrieving yet by {}:{:02}".format(self.params['CD'], self.params['CH'])), self.PGOPT['emllog'])
       return 0   # otherwise server file is not aged enough
 
-   # check if a Server file is changed with different size# return 1 - file changed, 2 - new file retrieved, 3 - force redlownload,
+   # check if a Server file is changed with different size
+   # return 1 - file changed, 2 - new file retrieved, 3 - force redlownload,
    #        0 - no change , -1 - error check, -2 - cannot check
    def check_newer_file(self, dcmd, cfile, ainfo):
+      """Determine whether the server file is newer than the local/archived copy.
+
+      Compares size, checksum, and modification time.  For wget, re-downloads
+      and returns 2 if the file changed.
+
+      Args:
+         dcmd (str): Download command pointing to the server file.
+         cfile (str | None): Comparison file path (local copy or empty string
+            to compare against the archive record only).
+         ainfo (dict): Archive info dict (chksm, asize, adate, atime).
+
+      Returns:
+         int: 1 = changed (download needed), 2 = new wget file retrieved,
+         3 = force re-download (cannot check), 0 = no change,
+         -1 = check error, -2 = unsupported command.
+      """
       if cfile:
          finfo = self.check_local_file(cfile, 33, self.PGOPT['wrnlog'])
          if not finfo: return 3   # download if can not check newer
@@ -1856,6 +2207,14 @@ class DsUpdt(PgUpdt, PgSplit):
 
    # get download action name
    def get_download_action(self, dcmd):
+      """Extract the download tool name from a command string for logging purposes.
+
+      Args:
+         dcmd (str | None): Download command string.
+
+      Returns:
+         str: Tool name such as 'wget', 'ncftpget', 'TAR', 'UNTAR', or 'DOWNLOAD'.
+      """
       if not dcmd: return "download"
       dact = "DOWNLOAD"
       ms = re.search(r'(^|\S\/)tar\s+-(\w+)\s', dcmd)
@@ -1873,6 +2232,19 @@ class DsUpdt(PgUpdt, PgSplit):
 
    # change to working directory if not there yet
    def change_workdir(self, wdir, locinfo, edate, ehour, FQ):
+      """Change the process working directory, applying environment and pattern substitution.
+
+      Args:
+         wdir (str | None): Target working directory (may contain ``$VAR`` or
+            temporal patterns).  Overridden by self.params['WD'] when present.
+         locinfo (str): Log label for error messages.
+         edate (str): End data date for pattern replacement.
+         ehour (int | None): End data hour.
+         FQ (list): Frequency array for pattern replacement.
+
+      Returns:
+         int: 1 on success, 0 on failure (logs an error).
+      """
       if 'WD' in self.params and self.params['WD'][0]: wdir = self.params['WD'][0]
       if not wdir:
          return self.pglog(locinfo + ": MISS working directory", self.PGOPT['emlerr'])
@@ -1884,6 +2256,19 @@ class DsUpdt(PgUpdt, PgSplit):
 
    # clean the working copies of remote and local files/directories
    def clean_files(self, cleancmd, edate, ehour, lfiles, rfiles, freq):
+      """Run the clean command to remove working copies of local/remote files.
+
+      Applies temporal and file-name substitutions to *cleancmd* before execution.
+      Missing-file errors from the shell command are treated as warnings.
+
+      Args:
+         cleancmd (str): Clean command template (may include -LF, -RF tokens).
+         edate (str): End data date for pattern replacement.
+         ehour (int | None): End data hour.
+         lfiles (list[str] | None): Local filenames to substitute for -LF.
+         rfiles (list | None): Remote file dicts/names to substitute for -RF.
+         freq (list): Frequency array for pattern replacement.
+      """
       lfile = ' '.join(lfiles) if lfiles else ''
       cleancmd = self.replace_pattern(cleancmd, edate, ehour, freq)
       cleancmd = self.executable_command(cleancmd, lfile, None, None, None, rfiles)
@@ -1893,6 +2278,21 @@ class DsUpdt(PgUpdt, PgSplit):
 
    # clean files rematching pattern on given date/hour
    def clean_older_files(self, cleancmd, workdir, locinfo, edate, locfile, rmtrecs, rcnt, tempinfo):
+      """Clean local and remote files that match patterns for a past valid-interval date.
+
+      Resolves filenames for the given *edate*, changes to the working directory,
+      and then calls clean_files().
+
+      Args:
+         cleancmd (str): Clean command template.
+         workdir (str): Working directory path.
+         locinfo (str): Log label.
+         edate (str): Valid-interval boundary date (files older than this are cleaned).
+         locfile (str): Local file pattern.
+         rmtrecs (dict): Remote file records.
+         rcnt (int): Number of remote file records.
+         tempinfo (dict): Temporal info dict.
+      """
       rfiles = None
       lfiles = self.get_local_names(locfile, tempinfo, edate)
       self.change_workdir(workdir, locinfo, edate, tempinfo['ehour'], tempinfo['FQ'])
@@ -1902,6 +2302,17 @@ class DsUpdt(PgUpdt, PgSplit):
 
    # get all remote file names for one update period
    def get_all_remote_files(self, rmtrecs, rcnt, tempinfo, edate):
+      """Collect all resolved remote filenames across every remote record for *edate*.
+
+      Args:
+         rmtrecs (dict): Remote file records (keyed by field name).
+         rcnt (int): Number of remote records.
+         tempinfo (dict): Temporal info dict.
+         edate (str): Date for pattern replacement.
+
+      Returns:
+         list: Flat list of remote file dicts from get_remote_names().
+      """
       rfiles = []
       for i in range(rcnt): # processs each remote record
          rmtrec = self.onerecord(rmtrecs, i)
@@ -1911,8 +2322,14 @@ class DsUpdt(PgUpdt, PgSplit):
          if files: rfiles.extend(files)
       return rfiles
 
-   # check remote file status and sed email to specialist for irregular update cases
+   # check remote file status and send email to specialist for irregular update cases
    def check_dataset_status(self):
+      """Check update readiness for all local files due before the current date.
+
+      Iterates over dlupdt records whose enddate is past, calls
+      check_locfile_status() for each, and builds an email summary.  Resets
+      the control time when a control record is active.
+      """
       if 'CD' in self.params:
          self.params['CD'] = self.format_date(self.params['CD'])   # standard format in case not yet
       else:
@@ -1951,6 +2368,18 @@ class DsUpdt(PgUpdt, PgSplit):
 
    # check update status for a given local file
    def check_locfile_status(self, locrec):
+      """Check whether the remote files for *locrec* are ready for the next update.
+
+      For each update period and remote record, calls check_remote_status() to
+      verify that the source file exists and is ready.  Accumulates counts in
+      self.PGOPT['lcnt'] and self.PGOPT['rcnt'].
+
+      Args:
+         locrec (dict): dlupdt local file record.
+
+      Returns:
+         int: 1 if any period was ready, 0 otherwise.
+      """
       loccnd = "lindex = {}".format(locrec['lindex'])
       lfile = locrec['locfile']
       locinfo = "{}-L{}".format(locrec['dsid'], locrec['lindex'])
@@ -2011,6 +2440,21 @@ class DsUpdt(PgUpdt, PgSplit):
 
    # check update status for given remote file
    def check_remote_status(self, rmtrec, lfile, locrec, locinfo, tempinfo):
+      """Verify that the remote files referenced by *rmtrec* are ready for download.
+
+      Resolves remote and server filenames, counts the path-pattern depth for
+      server-status polling, and checks each file's readiness.
+
+      Args:
+         rmtrec (dict): drupdt remote file record.
+         lfile (str): Local target filename.
+         locrec (dict): dlupdt local file record.
+         locinfo (str): Log label.
+         tempinfo (dict): Temporal info dict.
+
+      Returns:
+         int: 1 if all files are ready, 0 if any are not yet available.
+      """
       rfile = rmtrec['remotefile']
       rmtinfo = locinfo
       if not rfile:
@@ -2054,6 +2498,12 @@ class DsUpdt(PgUpdt, PgSplit):
 
    # process the update control records
    def process_update_controls(self):
+      """Dispatch pending update control records whose cntltime has arrived.
+
+      Queries dcupdt for unlocked records due by the current time, then calls
+      process_one_control() for each.  Stops after the first dispatched control
+      when no explicit -CI or -DS filter is active (to avoid flooding).
+      """
       ctime = self.curtime(1)
       if not ('CI' in self.params or 'DS' in self.params):
          self.set_default_value("SN", self.params['LN'])
@@ -2075,6 +2525,18 @@ class DsUpdt(PgUpdt, PgSplit):
 
    # process one update control
    def process_one_control(self, pgrec):
+      """Launch a background dsupdt process for a single update control record.
+
+      Validates the action, frequency, and specialist, checks data time
+      readiness, then runs ``dsupdt <dsid> <action> -CI <cidx> -d -b`` in the
+      background.
+
+      Args:
+         pgrec (dict): dcupdt control record.
+
+      Returns:
+         int: 1 if the process was successfully started, 0 otherwise.
+      """
       cidx = pgrec['cindex']
       cstr = "Control Index {}".format(cidx)
       if not pgrec['action']: return self.pglog(cstr + ": Miss update action", self.PGOPT['errlog'])
@@ -2101,6 +2563,20 @@ class DsUpdt(PgUpdt, PgSplit):
 
    # move the previous archived version controlled files
    def move_archived_file(self, ainfo, archived):
+      """Move an existing version-controlled web or saved file before re-archiving.
+
+      When the archive record indicates version control (vindex set), calls
+      dsarch MV to relocate the old file to a ``.vbu<n>`` backup name and marks
+      the local *archived* flag as 0 so the file is re-archived.
+
+      Args:
+         ainfo (dict): Archive info dict (wfile, sfile, wtype, stype, types).
+         archived (int): Current archived flag value.
+
+      Returns:
+         int: 0 if a version-controlled file was moved (triggering re-archive),
+         or the original *archived* value if no move was needed.
+      """
       stat = 0
       if 'wfile' in ainfo:
          type = ainfo['wtype']

--- a/src/rda_python_dsupdt/dsupdt.usg
+++ b/src/rda_python_dsupdt/dsupdt.usg
@@ -99,11 +99,11 @@ contained within that file.
 When retrieving update control, local file, or remote file information, Info
 options specify query conditions. The special characters '!', '<', '>', and
 '<>' can be used for more specific filtering. When supplied on the command line,
-these characters must be quoted or escaped to avoid OS interpretation. '!' (or
-\!) denotes exclusion and must appear immediately after the option name.
-'<' and '>' denote less-than and greater-than comparisons on the following value.
-'<>' denotes a range between two values. Combining '!' and '<' as "'!' '<'
-OptionValue" creates a 'greater than or equal to OptionValue' condition.
+these characters must be quoted or escaped to avoid shell interpretation. '!'
+(or \!) denotes exclusion and must appear immediately after the option name.
+'<' and '>' denote less-than and greater-than comparisons on the following
+value. '<>' denotes a range between two values. Combining '!' with '<' as
+'!' '<' OptionValue creates a 'greater than or equal to OptionValue' condition.
 
 The description of an individual option is displayed when 'dsupdt' is run as
 
@@ -134,21 +134,21 @@ number is provided.
 
 Actions are grouped into three categories based on the type of information they
 handle:
-  Configuration Actions - create, delete, modify and retrieve information of
-                          update controls, local files and remote files in GDEXDB,
-                          of a specified dataset
-All Information Actions - modify and retrieve information of update controls,
-                          local files and remote files of a specified dataset
-                          all together
+  Configuration Actions - create, delete, modify, and retrieve information for
+                          update controls, local files, and remote files in GDEXDB
+                          for a specified dataset
+All Information Actions - retrieve and modify all update control, local file,
+                          and remote file records for a specified dataset in a
+                          single operation
          Update Actions - download remote files, build local files, archive local
-                          files onto GDEX Servers, clean the temporary data files,
+                          files onto GDEX Servers, clean temporary data files,
                           check update status of files on remote servers, and
                           unlock update controls or local files that are locked
                           by aborted update processes.
 
 3.1 Configuration Actions
-   Update control, local file and remote file information can be created,
-   modified, viewed or deleted via Actions in this section:
+   Update control, local file, and remote file information can be created,
+   modified, viewed, or deleted via the actions in this section:
       Set Update Controls - create or modify information of update control
                             records for a given dataset
       Get Update Controls - retrieve information of update control records
@@ -250,12 +250,12 @@ ControlIndex<:>Specialist<:>ParentIndex<:>Action<:>Frequency<:>ControlOffset<:>C
   T      -(CT|ControlTime)      time to run dsupdt, format: YYYY-MM-DD HH:NN:SS
   R      -(RI|RetryInterval)    retry interval for failed dsupdt, i.e., 1M2D, 2H
   V      -(VI|ValidInterval)    update valid interval, i.e., 2D, 1M
-  U      -(UC|UpdateControl)    any of B-Begin,C-Current,E-Reset End Date/Time,
-                                F-Future,G-GMT,M-Multi,N-New,O-Miss,
-                                Y-Skip Feb. 29,Z-Allow Zero Filesize
-  J      -(MC|EMailControl)     one of A-All, E-Error, N-No, S-Summary, B-Summary when error
+  U      -(UC|UpdateControl)    any of B-Begin, C-Current, E-Reset End Date/Time,
+                                F-Future, G-GMT, M-Multi, N-New, O-Miss,
+                                Y-Skip Feb. 29, Z-Allow Zero Filesize
+  J      -(MC|EMailControl)     one of A-All, E-Error, N-No, S-Summary, B-Summary when Error
   E      -(EC|ErrorControl)     one of I-Ignore Error, Q-Quit on Error, N-Neither
-  K      -(KF|KeepFile)         one of S-Server File, R-Remote file, B-Keep Both, N-Neither
+  K      -(KF|KeepFile)         one of S-Server File, R-Remote File, B-Keep Both, N-Neither
   Z      -(HO|HourOffset)       time zone hour offset, hours ahead of local time
   D      -(DT|DataTime)         time data updated to, format: YYYY-MM-DD HH:NN:SS
   H      -(HN|HostName)         hostnames this cindex can/cannot be processed on
@@ -332,8 +332,8 @@ ControlIndex<:>Specialist<:>ParentIndex<:>Action<:>Frequency<:>ControlOffset<:>C
   Linking a local file record to an update control record (via -CI) causes the
   control record's scheduled action to run automatically against that local file.
 
-  For example, set update information of two new local files of d744004 via
-  input file 'd744004.loc'
+  For example, to set update information for two new local files of d744004 via
+  input file 'd744004.loc':
 
   dsupdt SL -NL -IF d744004.loc
 
@@ -484,8 +484,8 @@ LocalIndex<:>LocalFile<:>Action<:>ExecOrder<:>ControlIndex<:>FileArchived<:>Down
   E      -(ET|EndTime)          for remote file names, 0 - the last day/hour
   T      -(TI|TimeInterval)     for remote file names, i.e., 2H, 5D
 
-  If no dataset number is given, update information for all remote files across
-  all datasets owned by the specialist running 'dsupdt' may be viewed together.
+  If no dataset number is given, remote file update information for all datasets
+  owned by the specialist running 'dsupdt' is displayed.
 
 3.1.7 Delete Update Information
   -DL or -Delete (Alias: -RM|-Remove), deletes one or more update control,
@@ -581,7 +581,7 @@ LocalIndex<:>LocalFile<:>RemoteFile<:>ExecOrder<:>DownloadOrder<:>ServerFile<:>D
    -(MD|MyDataset) - sets information into GDEXDB regardless of dataset
                      ownership
   -(NC|NewControl) - sets a new update control record into GDEXDB
-  -(NL|NewLocfile) - sets a new  update record into GDEXDB
+  -(NL|NewLocfile) - sets a new update record into GDEXDB
   -(RO|ResetOrder) - resets the executing order indices of the local file
                      records according to the order as they are given per
                      option -LF (-LocalFile)
@@ -880,7 +880,7 @@ LocalIndex<:>LocalFile<:>RemoteFile<:>ExecOrder<:>DownloadOrder<:>ServerFile<:>D
          [-(CC|CarbonCopy) Cc'dEmailAddresses]
          [-(DB|Debug) DebugModeInfo]
 
-  Mode options that can be specified for the process-both-files Action:
+  Mode options that can be specified for this action:
         -(AW|AnyWhere) - works with Info option -BP (-BatchProcess) to allow
                          the recorded 'dsupdt' command to be started anywhere
       -(BG|BackGround) - background process; suppresses screen display of
@@ -941,9 +941,8 @@ LocalIndex<:>LocalFile<:>RemoteFile<:>ExecOrder<:>DownloadOrder<:>ServerFile<:>D
          [-(BP|BatchProcess) [BatchProcessHosts]]
          [-(CC|CarbonCopy) Cc'dEmailAddresses]
          [-(DB|Debug) DebugModeInfo]
-         [-(GZ|GMTZone) GreenwichMeanTimeZone]
 
-  Mode options that can be specified for the archive local files Action:
+  Mode options that can be specified for this action:
         -(AW|AnyWhere) - works with Info option -BP (-BatchProcess) to allow
                          the recorded 'dsupdt' command to be started anywhere
       -(BG|BackGround) - background process; suppresses screen display of
@@ -955,29 +954,27 @@ LocalIndex<:>LocalFile<:>RemoteFile<:>ExecOrder<:>DownloadOrder<:>ServerFile<:>D
      -(FU|ForceUpdate) - if present, forces archive for at least one end
                          date/time, even if the update is not yet due
          -(GZ|GMTZone) - uses GMT dates/times as controlling times
-    -(HU|HourlyUpdate) - forces update of time to hours after successful action
-                         of building local file
-     -(IE|IgnoreError) - works with Mode option -MU (-MultipleUpdate) to skip
-                         the errors for archiving local files and continue
-                         archive the later local files
-      -(MO|MissedOnly) - archive local file only if it is not archived yet
-  -(MU|MultipleUpdate) - allows archive multiple local files if multiple
-                         local files are available for different update periods;
-                         it defaults to archive a single local file if this Mode
-                         option is not present
-         -(NE|NoEmail) - does not send email to the specialist after archive
+    -(HU|HourlyUpdate) - advances time tracking to hours after a successful
+                         archive of a local file
+     -(IE|IgnoreError) - works with -MU (-MultipleUpdate) to skip archive
+                         errors and continue with remaining local files
+      -(MO|MissedOnly) - archives local file only if it has not been archived yet
+  -(MU|MultipleUpdate) - archives all available local files across multiple
+                         update periods; without this option, only one period
+                         is processed
+         -(NE|NoEmail) - suppresses post-archive email notification
       -(NY|NoLeapYear) - skips February 29 for leap years
-    -(RA|RetryArchive) - force archive of local files by passing option -RA
+    -(RA|RetryArchive) - forces re-archiving of local files by passing -RA
                          to 'dsarch'
-    -(RE|ResetEndTime) - if present, resets end date/hour based on the local file
-                         timestamp
-    -(SE|SummaryEmail) - send a summary email to the specialist after update
-                         without detail logging information
-    -(UB|UseBeginTime) - when present, use the beginning time of update period
-                         to replace temporal patterns of end time in file names
+    -(RE|ResetEndTime) - resets end date/hour when the file timestamp is newer
+                         than the end date/hour plus one update frequency
+    -(SE|SummaryEmail) - sends a summary-only email after the action, without
+                         detailed log information
+    -(UB|UseBeginTime) - uses the period's beginning time instead of end time
+                         when substituting temporal patterns in file names
                          and download commands
-      -(UT|UpdateTime) - forces to update the data end time and next due or
-                         update times
+      -(UT|UpdateTime) - forces an update of the data end time and next due
+                         update times regardless of whether archiving succeeds
 
   If a local file is not ready on the local disk, the archive action for this
   local file is skipped.
@@ -1003,7 +1000,7 @@ LocalIndex<:>LocalFile<:>RemoteFile<:>ExecOrder<:>DownloadOrder<:>ServerFile<:>D
          [-(CC|CarbonCopy) Cc'dEmailAddresses]
          [-(DB|Debug) DebugModeInfo]
 
-  Mode options that can be specified for the clean temporary files Action:
+  Mode options that can be specified for this action:
         -(AW|AnyWhere) - works with Info option -BP (-BatchProcess) to allow
                          the recorded 'dsupdt' command to be started anywhere
       -(BG|BackGround) - background process; suppresses screen display of
@@ -1038,12 +1035,12 @@ LocalIndex<:>LocalFile<:>RemoteFile<:>ExecOrder<:>DownloadOrder<:>ServerFile<:>D
   this information may not be cleared, preventing the record from being
   reprocessed on another host. Use this action to manually clear those locks.
 
-  dsupdt -(-UL|UnLockUpdate)
+  dsupdt -(UL|UnLockUpdate)
           -(CI|ControlIndex) UpdateControlIndices
          [-(DB|Debug) DebugModeInfo]
       or
 
-  dsupdt -(-UL|UnLockUpdate)
+  dsupdt -(UL|UnLockUpdate)
           -(LI|LocalIndex) LocfileIndices
          [-(DB|Debug) DebugModeInfo]
 
@@ -1098,8 +1095,9 @@ Mode options modify the behavior of Action options. All Mode options are
 optional and do not accept values.
 
   -AW or -AnyWhere, works with Info option -BP (-BatchProcess) to use an empty
-  working directory so that the recorded 'dsupdt' command can be started from
-  anywhere other than the directory where it was originally recorded.
+  working directory so that the recorded 'dsupdt' command can be executed from
+  any directory, rather than only from the directory where it was originally
+  recorded.
 
   -BG or -BackGround (Alias: -b), background process. When present, screen
   display is suppressed for both standard output and errors.
@@ -1141,8 +1139,8 @@ optional and do not accept values.
   -GZ or -GMTZone (Alias: -GMT|-GreenwichZone|-UTC), uses GMT rather than
   local time as the reference for update action scheduling.
 
-  -HU or -HourlyUpdate, forces the time tracking to advance in hourly increments
-  after a successful archive action for data file update.
+  -HU or -HourlyUpdate, forces time tracking to advance in hourly steps after
+  a successful data file archive.
 
   -IE or -IgnoreError, used with -MU (-MultipleUpdate) to skip failed updates
   and continue processing subsequent periods. For records with a valid interval
@@ -1194,8 +1192,8 @@ optional and do not accept values.
 
   -RO or -ResetOrder (Alias: -Reorder), resets execution order indices to match
   the sequence in which local files are provided to -SL (-SetLocalFile).
-  Alternatively, explicit order indices can be supplied via -XO (-ExecOrder).
-  Valid values are 1, 2, 3, ...
+  Alternatively, explicit order indices can be supplied via -XO (-ExecOrder);
+  valid order index values are 1, 2, 3, ...
 
   -SE or -SummaryEmail, sends a brief summary email after the update action,
   omitting detailed log information.
@@ -1225,10 +1223,11 @@ Information (Info) options supply values to 'dsupdt'. There are two types:
   -BP or -BatchProcess (Alias: -d, -DelayedMode), delayed mode execution. When
   present, the 'dsupdt' command is not executed immediately; instead, the command
   information is recorded in GDEXDB and executed later by the daemon 'dscheck'.
-  One or more host names may be specified after -BP to restrict execution to or
-  exclude specific hosts. For example, '-d PBS' runs on Portable Batch System (PBS)
-  hosts. An upper limit on retry attempts (1 to 99) can also be set, e.g., '-d 2'.
-  Defaults to 1 retry for 'dsupdt' commands if not specified.
+  One or more host names may be specified after -BP to restrict execution to
+  specific hosts (or exclude them if prefixed with '!'). For example, '-d PBS'
+  restricts execution to Portable Batch System (PBS) hosts. An upper limit on
+  retry attempts (1 to 99) can also be specified; for example, '-d 2' limits
+  retries to 2. If not specified, the default retry count is 1.
 
   -CD or -CurrentDate, provides an alternative current date for update actions.
   This allows specialists to rerun an update for re-archiving or recovering a
@@ -1241,7 +1240,7 @@ Information (Info) options supply values to 'dsupdt'. There are two types:
   -DS or -Dataset, the dataset ID in the format [a-z]NNNNNN.
 
   -DV or -Divider (Alias: -Delimiter, -Separator), delimiter for separating
-  columns of multi-value Info options in input files. Defaults to '<:>'.
+  column values of multi-value Info options in input files. Defaults to '<:>'.
 
   -ES or -EqualSign, sets the delimiter used to assign values to options in
   input files. Defaults to '<=>'.
@@ -1371,8 +1370,8 @@ Information (Info) options supply values to 'dsupdt'. There are two types:
 
   -ED or -EndDate, the data end date of the next update period.
 
-  -EH or -EndHour, the data end hour of the next update period, for hourly
-  updates.
+  -EH or -EndHour, the data end hour of the next update period. Applicable only
+  to datasets with sub-daily (hourly) update frequencies.
 
   Local file dependencies are configured via -PI (-ParentIndex). When set, a
   local file record is blocked for a given end date (and hour, if applicable)
@@ -1402,7 +1401,7 @@ Information (Info) options supply values to 'dsupdt'. There are two types:
   patterns on the command line. The first value replaces '<P0>', the second
   '<P1>', and so on.
 
-  When two patterns are used (<P0> and <P1>), providing n*2 values causes the
+  When two patterns are used (<P0> and <P1>), providing 2n values causes the
   substitution to loop n times (n > 0).
 
   -HN or -HostName, one or more host names stored in an update control record
@@ -1428,7 +1427,7 @@ Information (Info) options supply values to 'dsupdt'. There are two types:
   OptionName<=>OptionValue, one per line. The Action/Mode option sign can be
   changed via -AO (-ActOption, default '<!>'); the assignment sign can be changed
   via -ES (-EqualSign, default '<=>').  Multi-value assignments are column-
-  delimited using the separator set by -SP (-Separator, default '<:>'). A column
+  delimited using the separator set by -DV (-Divider, default '<:>'). A column
   title line precedes the data rows. Data ends at the end of the file or when a
   new column title line or single-value assignment is encountered. If the last
   column contains multi-line values, an additional separator must be appended to
@@ -1524,7 +1523,7 @@ Information (Info) options supply values to 'dsupdt'. There are two types:
   is available from multiple servers.
 
   Multiple remote files can be provided in a single remote file record by joining
-  them with separator '::', as Rfile1::Rfile2::Rfile3 for example.
+  them with '::' as a separator, for example: Rfile1::Rfile2::Rfile3.
 
   A remote file name beginning with '!' is treated as a shell command; its
   output is used as the dynamically generated remote file name.
@@ -1572,9 +1571,8 @@ Information (Info) options supply values to 'dsupdt'. There are two types:
   download and archive operations. The root path can be set via the environment
   variable $UPDTWKP, which defaults to '/glade/data02/dsswork' on machines with
   write access to /glade/data02. For example, '$UPDTWKP/zji/icoads' resolves to
-  '/glade/data02/dsswork/zji/icoads'. To use a different root, set $UPDTWKP
-  accordingly; if a different variable name is used without being defined, the
-  default value of $UPDTWKP applies.
+  '/glade/data02/dsswork/zji/icoads'. To use a different root path, set the
+  $UPDTWKP environment variable before running 'dsupdt'.
 
   -XC or -ExecuteCommand (Alias: -ExecCmd), an external command run after a
   successful update action for a given update control configuration.

--- a/src/rda_python_dsupdt/pg_updt.py
+++ b/src/rda_python_dsupdt/pg_updt.py
@@ -22,8 +22,16 @@ from rda_python_common.pg_cmd import PgCMD
 from rda_python_common.pg_opt import PgOPT
 
 class PgUpdt(PgOPT, PgCMD):
+   """Base class providing common update utility functions for dataset updates.
+
+   Extends PgOPT and PgCMD to handle update control records, local/remote file
+   management, temporal pattern replacement, and dataset update scheduling in RDADB.
+   Defines option codes, aliases, table hash mappings, and shared counters used by
+   the DsUpdt subclass.
+   """
 
    def __init__(self):
+      """Initialize option/alias tables, table hash mappings, and update counters."""
       super().__init__()  # initialize parent class
       self.CORDERS = {}
       self.OPTS.update({
@@ -284,6 +292,21 @@ class PgUpdt(PgOPT, PgCMD):
 
    # get file contion
    def file_condition(self, tname, include = None, exclude = None, nodsid = 0):
+      """Build a SQL WHERE condition string for filtering update records.
+
+      Iterates over the field hash for the given table name and constructs a
+      condition from option values present in self.params.  A ``dsid`` prefix
+      is prepended unless *nodsid* is set.
+
+      Args:
+         tname (str): Table name key into self.TBLHASH (e.g. 'dlupdt', 'drupdt').
+         include (str | None): If given, only keys in this string are included.
+         exclude (str | None): If given, keys in this string are skipped.
+         nodsid (int): When non-zero, omit the leading ``dsid = '...'`` clause.
+
+      Returns:
+         str: SQL condition fragment (without a leading ``AND``).
+      """
       condition = ""
       hash = self.TBLHASH[tname]
       noand = 1 if nodsid else 0
@@ -305,6 +328,17 @@ class PgUpdt(PgOPT, PgCMD):
    # check if enough information entered on command line and/or input file
    # for given action(s)
    def check_enough_options(self, cact, acts):
+      """Validate that sufficient options have been supplied for the requested action.
+
+      Raises an action error if required indices or file names are missing.
+      Also performs one-time setup tasks: sets the uid, configures batch/daemon
+      mode, applies no-leap-year and email suppression flags, and starts the
+      none-daemon process manager.
+
+      Args:
+         cact (str): The current action key (e.g. 'UF', 'SC', 'SL').
+         acts (int): Bitmask of all requested actions from self.PGOPT['ACTS'].
+      """
       errmsg = [
          "Miss dataset number per -DS(-Dataset)",
          "Miss local file names per -LF(-LocalFile)",
@@ -373,6 +407,13 @@ class PgUpdt(PgOPT, PgCMD):
 
    # get the associated dataset id
    def get_dsupdt_dataset(self):
+      """Return the dataset ID associated with the current operation.
+
+      Checks self.params in order: 'DS', 'CI' (control index), 'LI' (local index).
+
+      Returns:
+         str | None: Dataset ID string, or None if not determinable.
+      """
       if 'DS' in self.params: return self.params['DS']
       if 'CI' in self.params and self.params['CI'][0]:
          pgrec = self.pgget("dcupdt", "dsid", "cindex = {}".format(self.params['CI'][0]), self.PGOPT['extlog'])
@@ -385,6 +426,25 @@ class PgUpdt(PgOPT, PgCMD):
    # replace the temoral patterns in given fname with date/hour
    # return pattern array only if not date
    def replace_pattern(self, fname, date, hour = None, intv = None, limit = 0, bdate = None, bhour = None):
+      """Replace temporal placeholder patterns in a filename with actual date/hour values.
+
+      Patterns are delimited by self.params['PD'] (default ``<`` and ``>``).
+      Supported pattern types include: generic (``P<n>``), current-date (``C…C``),
+      month-fraction (``M[NC]M``), sequence number (``N[HD]+N``), back-shifted
+      (``B…B``), Wednesday-aligned (``W…W``), and standard date-format strings.
+
+      Args:
+         fname (str | None): Filename containing zero or more patterns.
+         date (str | int | None): End data date (YYYY-MM-DD).
+         hour (int | None): End data hour (0-23), or None for daily data.
+         intv (list | None): Frequency interval array [Y, M, D, H, …].
+         limit (int): Maximum number of patterns to replace (0 = unlimited).
+         bdate (str | None): Beginning date of the update period.
+         bhour (int | None): Beginning hour of the update period.
+
+      Returns:
+         str | None: Filename with patterns replaced, or None if *fname* is falsy.
+      """
       if not fname: return None
       if date and not isinstance(date, str): date = str(date)
       if bdate and not isinstance(bdate, str): bdate = str(bdate)
@@ -477,6 +537,19 @@ class PgUpdt(PgOPT, PgCMD):
 
    # get next display order of an archived data file of given dataset (and group)
    def get_next_exec_order(self, dsid, next):
+      """Return the next execution order value for a local file record of *dsid*.
+
+      Caches the current maximum ``execorder`` per dataset in self.CORDERS.
+      Passing *dsid* as None resets the cache.
+
+      Args:
+         dsid (str | None): Dataset ID, or None to reset the cache.
+         next (int): If non-zero, query the database for the current maximum
+            order when the dataset is not already cached.
+
+      Returns:
+         int | None: Incremented execution order, or None when *dsid* is None.
+      """
       if not dsid:
          self.CORDERS = {}   # reinitial lize cached display orders
          return
@@ -489,6 +562,24 @@ class PgUpdt(PgOPT, PgCMD):
 
    # execute specialist specified command
    def executable_command(self, cmd, file, dsid, edate, ehour, rfiles = None):
+      """Expand placeholder tokens in a specialist-defined shell command string.
+
+      Replaces ``__FN__``/``__FNAME__``/``__FILENAME__``, ``-LF``/``-RF``/``-SF``,
+      ``-DS``, ``-ED``, ``-EH``, ``-SN``/``-LN``, and ``-LI`` with the
+      corresponding runtime values.  Returns None for commented-out (``#``) or
+      empty commands.
+
+      Args:
+         cmd (str | None): Raw command template.
+         file (str | None): Local or server filename to substitute.
+         dsid (str | None): Dataset ID.
+         edate (str | int | None): End data date.
+         ehour (int | None): End data hour.
+         rfiles (list | None): List of remote file names or dicts for ``-RF``.
+
+      Returns:
+         str | None: Expanded command string, or None if *cmd* is falsy/commented.
+      """
       if not cmd or re.match(r'^#', cmd): return None
       if re.search(r'\$', cmd): cmd = self.replace_environments(cmd, None, self.PGOPT['emlerr'])
       if file:
@@ -535,6 +626,20 @@ class PgUpdt(PgOPT, PgCMD):
 
    # get the local file names
    def get_local_names(self, lfile, tempinfo, edate = None):
+      """Resolve the list of local filenames for a given update period.
+
+      If *lfile* starts with ``!``, the remainder is treated as an executable
+      command whose stdout (``::``-delimited) provides the names.  Otherwise
+      serial patterns are expanded and temporal placeholders replaced.
+
+      Args:
+         lfile (str): Local file pattern or ``!command``.
+         tempinfo (dict): Temporal info dict (must contain 'ehour', 'edate').
+         edate (str | None): Override end date; defaults to tempinfo['edate'].
+
+      Returns:
+         list | None: List of resolved filenames, or None if none found.
+      """
       locfiles = []
       ehour = tempinfo['ehour']
       if not edate: edate = tempinfo['edate']
@@ -553,6 +658,19 @@ class PgUpdt(PgOPT, PgCMD):
 
    # expend serial pattern
    def expand_serial_pattern(self, fname):
+      """Expand a serial index pattern (``<S start:end:step S>``) in a filename.
+
+      The pattern ``<Sstart:end:stepS>`` (or ``<Sstart:endS>`` with step=1) is
+      replaced by each zero-padded integer in the range, producing a list of
+      filenames.  Returns a single-element list with the original name when no
+      such pattern is found.
+
+      Args:
+         fname (str | None): Filename possibly containing a serial pattern.
+
+      Returns:
+         list | None: Expanded list of filenames, or None if *fname* is falsy.
+      """
       if not fname: return None
       seps = self.params['PD']
       ms = re.search(r'{}S(\d[\d:]+\d)S{}'.format(seps[0], seps[1]), fname)
@@ -575,6 +693,23 @@ class PgUpdt(PgOPT, PgCMD):
 
    # get the remote file names
    def get_remote_names(self, rfile, rmtrec, rmtinfo, tempinfo, edate = None):
+      """Resolve the list of remote filenames for a given update period.
+
+      If *rfile* starts with ``!``, the remainder is executed as a command.
+      Otherwise serial patterns are expanded and each element is passed through
+      replace_remote_pattern_times() to produce one or more timestamped names.
+
+      Args:
+         rfile (str): Remote file pattern or ``!command``.
+         rmtrec (dict): Remote file database record (tinterval, begintime, etc.).
+         rmtinfo (str): Log-friendly label for this remote entry.
+         tempinfo (dict): Temporal info dict for the current update period.
+         edate (str | None): Override end date; defaults to tempinfo['edate'].
+
+      Returns:
+         list | None: List of remote file dicts (with 'fname', 'ready', etc.),
+         or None if none found.
+      """
       rmtfiles = []
       if not edate: edate = tempinfo['edate']
       if rfile[0] == '!':   # executable for build up remote file names
@@ -592,6 +727,22 @@ class PgUpdt(PgOPT, PgCMD):
 
    # get and replace pattern dates/hours for remote files
    def replace_remote_pattern_times(self, rfile, rmtrec, rmtinfo, tempinfo, edate = None):
+      """Expand a single remote filename pattern over its time interval range.
+
+      When a remote record has a ``tinterval`` field, this method generates one
+      remote file dict per sub-period within the update window (from begintime
+      to endtime).  Without a time interval a single dict is returned.
+
+      Args:
+         rfile (str): Remote file pattern with optional temporal placeholders.
+         rmtrec (dict): Remote file DB record (tinterval, begintime, endtime).
+         rmtinfo (str): Log label for this remote record.
+         tempinfo (dict): Temporal info for the current update period.
+         edate (str | None): Override end date; defaults to tempinfo['edate'].
+
+      Returns:
+         list: List of remote file dicts; empty on error.
+      """
       rfiles = []
       if not edate: edate = tempinfo['edate']
       ehour = tempinfo['ehour']
@@ -723,6 +874,25 @@ class PgUpdt(PgOPT, PgCMD):
 
    # get one hash array for a single remote file name
    def one_remote_filename(self, fname, date, hour, tempinfo, intv, bdate, bhour):
+      """Build a remote file descriptor dict for a single date/hour.
+
+      Resolves the filename pattern, determines readiness relative to the
+      current date, and packages metadata (date, hour, time string, download
+      command) into a dict used downstream by download_remote_files().
+
+      Args:
+         fname (str): Remote file pattern.
+         date (str): Data date for this file (YYYY-MM-DD).
+         hour (int | None): Data hour, or None for daily data.
+         tempinfo (dict): Temporal info dict (FQ, NX, VD/VH, DC, etc.).
+         intv (list | None): Interval array; falls back to tempinfo['FQ'].
+         bdate (str): Beginning date of the update period.
+         bhour (int | None): Beginning hour of the update period.
+
+      Returns:
+         dict: Remote file descriptor with keys 'fname', 'ready', 'amiss',
+         'date', 'hour', 'time', and 'rcmd'.
+      """
       if tempinfo['NX']:
          (udate, uhour) = self.adddatehour(date, hour, tempinfo['NX'][0], tempinfo['NX'][1], tempinfo['NX'][2], tempinfo['NX'][3])
       else:
@@ -758,6 +928,21 @@ class PgUpdt(PgOPT, PgCMD):
 
    # record the date/hour for missing data
    def set_miss_time(self, lfile, locrec, tempinfo, rmonly = 0):
+      """Update the missdate/misshour fields in the dlupdt record for a local file.
+
+      When valid-interval tracking is active, this records the earliest date at
+      which remote data became missing.  Passing *rmonly* = 1 clears the miss
+      timestamp only when it matches the current end date/hour.
+
+      Args:
+         lfile (str): Local filename (used for logging context).
+         locrec (dict): Local file DB record (lindex, missdate, misshour, etc.).
+         tempinfo (dict): Temporal info dict (edate, ehour, VD, VH).
+         rmonly (int): If 1, remove the miss-time rather than set it.
+
+      Returns:
+         int: 1 if a miss-time remains set, 0 otherwise.
+      """
       setmiss = 1
       mdate = mhour = None
       pgrec = {}
@@ -790,6 +975,20 @@ class PgUpdt(PgOPT, PgCMD):
 
    # reset next data end/update times
    def reset_update_time(self, locinfo, locrec, tempinfo, arccnt, endonly):
+      """Advance the dlupdt end-date and optionally update the dsperiod record.
+
+      After successfully archiving files, advances the stored ``enddate``/
+      ``endhour`` to the next update period.  Also calls ``sdp`` to extend
+      the dataset time coverage when the data period has grown.
+
+      Args:
+         locinfo (str): Log label for the current local file.
+         locrec (dict): Local file DB record (lindex, enddate, endhour, gindex, etc.).
+         tempinfo (dict): Temporal info (edate, ehour, FQ, EP, QU, NX).
+         arccnt (int): Number of files successfully archived in this pass.
+         endonly (int): If non-zero, skip the enddate advancement when no files
+            were archived.
+      """
       gx = 1 if re.search(r'(^|\s)-GX(\s|$)', locrec['options'], re.I) else 0
       date = tempinfo['edate']
       hour = tempinfo['ehour']
@@ -839,6 +1038,20 @@ class PgUpdt(PgOPT, PgCMD):
 
    # get period record for sub group
    def get_period_record(self, gindex, dsid, locinfo):
+      """Fetch the dsperiod record for a dataset group, traversing parent groups.
+
+      Looks up the period record for *gindex* in dsperiod; if not found and the
+      group has a parent (dsgroup.pindex), recurses to find the parent's period.
+      Logs an error and returns None if date_end is the sentinel '0000-00-00'.
+
+      Args:
+         gindex (int): Group index to look up.
+         dsid (str): Dataset ID.
+         locinfo (str): Log label for error messages.
+
+      Returns:
+         dict | None: dsperiod record dict, or None if not found/invalid.
+      """
       pgrec = self.pgget("dsperiod", "gindex, date_end, time_end, dorder",
                           "dsid = '{}' AND gindex = {} ORDER BY dorder".format(dsid, gindex), self.PGOPT['extlog'])
       if not pgrec and gindex:
@@ -851,6 +1064,19 @@ class PgUpdt(PgOPT, PgCMD):
 
    # check if need time interval for remote/server file
    def need_time_interval(self, fname, freq):
+      """Return True if the remote filename pattern implies a finer time interval.
+
+      Warns when the temporal units embedded in *fname* are at a finer
+      granularity than the dataset update frequency, suggesting that a
+      ``tinterval`` should be set in the remote file record.
+
+      Args:
+         fname (str): Remote filename pattern.
+         freq (list): Frequency array [Y, M, D, H, …] from get_control_time().
+
+      Returns:
+         int: 1 if a time interval appears needed, 0 otherwise.
+      """
       units = self.temporal_pattern_units(fname, self.params['PD'])
       if not units: return 0   # no temporal pattern found in file name    
       funit = punit = None
@@ -881,6 +1107,19 @@ class PgUpdt(PgOPT, PgCMD):
 
    # check if local file is a growing one
    def is_growing_file(self, fname, freq):
+      """Determine whether a local file is expected to grow with each update.
+
+      A file is considered *growing* when its name contains no temporal pattern
+      that matches the update frequency granularity, meaning the same physical
+      file is appended to rather than replaced each cycle.
+
+      Args:
+         fname (str): Local filename pattern.
+         freq (list): Frequency array [Y, M, D, H, …].
+
+      Returns:
+         int: 1 if the file is growing, 0 if it is replaced each period.
+      """
       units = self.temporal_pattern_units(fname, self.params['PD'])
       if not units: return 1   # no temporal pattern found in file name    
       if freq[3] > 0:
@@ -896,6 +1135,19 @@ class PgUpdt(PgOPT, PgCMD):
    # add update frequency to date/hour
    # opt = -1 - minus, 0 - begin time, 1 - add (default)
    def addfrequency(self, date, hour, intv, opt = 1):
+      """Add (or subtract) an update frequency interval to a date/hour.
+
+      Args:
+         date (str | int | None): Starting date (YYYY-MM-DD).
+         hour (int | None): Starting hour, or None for daily granularity.
+         intv (list | None): Frequency array [Y, M, D, H, min, sec, frac_month].
+            Returns (date, hour) unchanged when *intv* is falsy.
+         opt (int): 1 to add (default), -1 to subtract, 0 to return the
+            beginning of the next period.
+
+      Returns:
+         tuple[str, int | None]: Updated (date, hour) pair.
+      """
       if date and not isinstance(date, str): date = str(date)
       if not intv: return (date, hour)
       freq = intv.copy()
@@ -920,6 +1172,12 @@ class PgUpdt(PgOPT, PgCMD):
 
    #  send a cumtomized email if built during specialist's process
    def send_updated_email(self, lindex, locinfo):
+      """Send a specialist-built custom email stored in dlupdt.emnote, then clear it.
+
+      Args:
+         lindex (int): Local file index whose emnote field to check and send.
+         locinfo (str): Log label used if sending fails.
+      """
       pgrec = self.pgget("dlupdt", "emnote", "lindex = {}".format(lindex), self.LOGERR)
       if not (pgrec and pgrec['emnote']): return   # no customized email info to send   
       if not self.send_customized_email(locinfo, pgrec['emnote'], self.PGOPT['emllog']): return
@@ -927,6 +1185,18 @@ class PgUpdt(PgOPT, PgCMD):
 
    # validate given local indices
    def validate_lindices(self, cact):
+      """Validate local file indices in self.params['LI'] against RDADB.
+
+      Converts string values to integers, resolves comparison-operator tokens
+      (``!``, ``<``, ``>``) into matching index lists, and verifies ownership.
+      Sets a validated flag on self.OPTS['LI'] to avoid re-validation.
+
+      Args:
+         cact (str): Current action key (used to enforce -NL for new records).
+
+      Returns:
+         int: Count of zero-valued (new-record) indices.
+      """
       if (self.OPTS['LI'][2]&8) == 8: return 0  # already validated
       zcnt = 0
       lcnt = len(self.params['LI'])
@@ -971,6 +1241,19 @@ class PgUpdt(PgOPT, PgCMD):
 
    # validate given control indices
    def validate_cindices(self, cact):
+      """Validate update control indices in self.params['CI'] (or 'ID') against RDADB.
+
+      Converts string values to integers, resolves comparison/wildcard tokens
+      into matching index lists, verifies that each index exists, and enforces
+      single-control-per-invocation for update/check actions.  Falls back to
+      cid2cindex() when 'ID' is provided instead of 'CI'.
+
+      Args:
+         cact (str): Current action key.
+
+      Returns:
+         int: Count of zero-valued (new-control) indices.
+      """
       if (self.OPTS['CI'][2] & 8) == 8: return 0   # already validated
       zcnt = 0
       if 'CI' in self.params:
@@ -1020,6 +1303,19 @@ class PgUpdt(PgOPT, PgCMD):
 
    # get control index array from given control IDs
    def cid2cindex(self, cact, cntlids, zcnt):
+      """Convert a list of control ID strings to their corresponding cindex values.
+
+      Performs an exact-match DB lookup for normal IDs and a wildcard/comparison
+      query for patterns containing ``%``, ``!``, ``<``, or ``>``.
+
+      Args:
+         cact (str): Current action key (used to allow new-record creation).
+         cntlids (list[str]): List of control ID strings from self.params['ID'].
+         zcnt (int): Running count of zero-index (new-record) placeholders.
+
+      Returns:
+         list[int]: List of resolved cindex integers.
+      """
       count = len(cntlids) if cntlids else 0
       if count == 0: return None
       i = 0
@@ -1057,6 +1353,21 @@ class PgUpdt(PgOPT, PgCMD):
 
    # check remote server file information
    def check_server_file(self, dcmd, opt, cfile):
+      """Retrieve metadata for the source file referenced by a download command.
+
+      Parses the command to identify the transfer protocol (rdacp, cp/mv, tar,
+      ncftpget, wget, or generic) and delegates to the appropriate
+      check_*_file() helper.  The returned dict includes a 'ftype' key
+      indicating the protocol detected.
+
+      Args:
+         dcmd (str): Download command string.
+         opt (int): Option bitmask passed to the underlying check helper.
+         cfile (str | None): Comparison file path for wget-based newer checks.
+
+      Returns:
+         dict | None: File info dict (data_size, date_modified, etc.) or None.
+      """
       sfile = info = type = None
       self.PGLOG['SYSERR'] = self.PGOPT['STATUS'] = ''
       docheck = 1
@@ -1164,6 +1475,14 @@ class PgUpdt(PgOPT, PgCMD):
 
    # check and sleep if given web site need to be slowdown for accessing
    def slow_web_access(self, wbuf):
+      """Sleep to rate-limit access to web servers that require throttling.
+
+      Checks *wbuf* against the self.WSLOWS dictionary (hostname → sleep
+      seconds) and sleeps the configured number of seconds when a match is found.
+
+      Args:
+         wbuf (str): URL or command string that may contain a known slow hostname.
+      """
       for wsite in self.WSLOWS:
          if wbuf.find(wsite) > -1:
             time.sleep(self.WSLOWS[wsite])
@@ -1172,6 +1491,19 @@ class PgUpdt(PgOPT, PgCMD):
    # return 1 if exists; 0 missed, -1 with error, -2 comand not surported yet
    # an error message is stored in self.PGOPT['STATUS'] if not success
    def check_server_status(self, dcmd):
+      """Check whether the remote source file referenced by a download command exists.
+
+      Dispatches to the appropriate protocol handler (rdacp, mv/cp/tar,
+      ncftpget, wget, or generic) based on the command content.
+
+      Args:
+         dcmd (str): Download command string.
+
+      Returns:
+         int: 1 if the file exists, 0 if not found (possibly just not ready),
+         -1 on a recoverable error, -2 on an unrecoverable error or unsupported
+         command.
+      """
       self.PGOPT['STATUS'] = ''
       target = None
       ms = re.search(r'(^|\s|\||\S/)rdacp\s+(.+)$', dcmd)
@@ -1248,9 +1580,25 @@ class PgUpdt(PgOPT, PgCMD):
       return -2
 
    # check status for remote server/file via wget
-   # return self.SUCCESS if file exist and self.FAILURE otherwise. 
+   # return self.SUCCESS if file exist and self.FAILURE otherwise.
    # file status message is returned via reference string of $status
    def check_wget_status(self, server, fname, user, pswd):
+      """Check the existence of a remote file on an HTTP/HTTPS server using wget --spider.
+
+      Walks up the directory tree (up to self.PGOPT['PCNT'] levels) if the
+      exact path is not found, to distinguish a missing file from an
+      inaccessible server.
+
+      Args:
+         server (str): Base server URL (e.g. ``https://example.com``).
+         fname (str): File path on the server.
+         user (str | None): HTTP username (wget --user).
+         pswd (str | None): HTTP password (wget --password).
+
+      Returns:
+         int: 1 if found, 0 if not yet present (parent dir exists),
+         -1 if file is missing, -2 on a server/network error.
+      """
       cmd = "wget --spider --no-check-certificate "
       if user or pswd:
          self.PGOPT['STATUS'] = "{}{}: {}".format(server, fname, self.PGLOG['MISSFILE'])
@@ -1284,9 +1632,24 @@ class PgUpdt(PgOPT, PgCMD):
          i += 1
 
    # check status for remote server/file via check_ftp_file()
-   # return self.SUCCESS if file exist and self.FAILURE otherwise. 
+   # return self.SUCCESS if file exist and self.FAILURE otherwise.
    # file status message is returned via reference string of $status
    def check_ftp_status(self, server, fname, user, pswd):
+      """Check the existence of a remote file on an FTP server using ncftpls.
+
+      Walks up the directory tree on missing entries to distinguish a missing
+      file from an inaccessible parent directory or server.
+
+      Args:
+         server (str): FTP server URL (e.g. ``ftp://data.example.com``).
+         fname (str): File path on the server.
+         user (str | None): FTP username.
+         pswd (str | None): FTP password.
+
+      Returns:
+         int: 1 if found, 0 if not yet present, -1 if file is missing,
+         -2 on an unrecoverable server error.
+      """
       cmd = "ncftpls "
       if user: cmd += "-u {} ".format(user)
       if pswd: cmd += "-p {} ".format(pswd)
@@ -1319,6 +1682,19 @@ class PgUpdt(PgOPT, PgCMD):
 
    # check remote server status
    def check_remote_status(self, host, fname):
+      """Check the existence of a file on an RDA remote host via ``<host>-sync``.
+
+      Walks up the path tree to distinguish a missing file from an inaccessible
+      parent directory.
+
+      Args:
+         host (str): Remote host prefix used to construct ``<host>-sync``.
+         fname (str): File path to check on the remote host.
+
+      Returns:
+         int: 1 if found, 0 if not yet present, -1 if file is missing,
+         -2 on error.
+      """
       pname = None
       i = 0
       while True:
@@ -1344,6 +1720,18 @@ class PgUpdt(PgOPT, PgCMD):
 
    # check local disk status
    def check_local_status(self, fname):
+      """Check the existence of a path on the local filesystem.
+
+      Walks up the directory tree to distinguish a missing file from a missing
+      parent directory, returning different codes for each case.
+
+      Args:
+         fname (str): Absolute or relative path to check.
+
+      Returns:
+         int: 1 if path exists, 0 if parent exists but file does not,
+         -1 if file is missing, -2 on error.
+      """
       pname = None
       i = 0
       while True:
@@ -1365,6 +1753,16 @@ class PgUpdt(PgOPT, PgCMD):
 
    # check tar file status
    def check_tar_status(self, fname, target):
+      """Check whether *target* exists inside a local tar archive *fname*.
+
+      Args:
+         fname (str): Path to the tar file.
+         target (str): Member path to look for within the archive.
+
+      Returns:
+         int: 1 if the member exists, 0 if the archive exists but the member
+         does not, -1 on error.
+      """
       stat = self.check_local_status(fname)
       if stat < 1: return stat
       msg = self.pgsystem("tar -tvf {} {}".format(fname, target), self.LOGWRN, 272)   # 16+256
@@ -1380,6 +1778,17 @@ class PgUpdt(PgOPT, PgCMD):
 
    # count directories with temoral patterns in given path
    def count_pattern_path(self, dcmd):
+      """Count the number of path components containing temporal patterns in a command.
+
+      Used to determine how many directory levels to walk up when checking
+      file existence on a remote server.
+
+      Args:
+         dcmd (str): Download command string.
+
+      Returns:
+         int: Number of pattern-containing path levels (minimum 1).
+      """
       getpath = 1
       ms = re.search(r'(^|\s|\||\S/)rdacp\s+(.+)$', dcmd)
       if ms:
@@ -1427,6 +1836,21 @@ class PgUpdt(PgOPT, PgCMD):
 
    # check error message for download action
    def parse_download_error(self, err, act, sinfo = None):
+      """Classify a download error message and determine whether to retry or abort.
+
+      Returns a (status, error_message) tuple where status follows the
+      convention: 1 = success, 0 = recoverable missing, -1 = error continue,
+      -2 = unrecoverable error.
+
+      Args:
+         err (str): Stderr output from the download command.
+         act (str): Download action name (e.g. 'wget', 'ncftpget', 'UNTAR').
+         sinfo (dict | None): File info dict from check_local_file(); if
+            provided, size validation takes precedence over *err*.
+
+      Returns:
+         tuple[int, str]: (status_code, cleaned_error_message).
+      """
       derr = ''
       stat = 0
       if sinfo:
@@ -1454,6 +1878,19 @@ class PgUpdt(PgOPT, PgCMD):
 
    # cache update control information
    def cache_update_control(self, cidx, dolock = 0):
+      """Load a dcupdt control record into self.PGOPT['UCNTL'] and apply its settings.
+
+      Validates the dataset ID, hostname restrictions, and data time.  Applies
+      control flags (updtcntl, emailcntl, errorcntl, keepfile) to self.params,
+      caches associated data times, and optionally acquires an exclusive lock.
+
+      Args:
+         cidx (int): Control index (dcupdt.cindex) to cache.
+         dolock (int): If non-zero, acquire an exclusive update-control lock.
+
+      Returns:
+         bool: self.SUCCESS on success, self.FAILURE on any validation error.
+      """
       cstr = "C{}".format(cidx)
       pgrec = self.pgget("dcupdt", "*", "cindex = {}".format(cidx), self.PGOPT['emlerr'])
       if not pgrec: return self.pglog(cstr + ": update control record NOT in RDADB", self.PGOPT['errlog'])
@@ -1515,6 +1952,12 @@ class PgUpdt(PgOPT, PgCMD):
 
    # cache date time info
    def cache_data_time(self, cidx):
+      """Pre-populate self.PGOPT['DTIMES'] with enddate/endhour for all local files
+      associated with control index *cidx*.
+
+      Args:
+         cidx (int): Control index whose dlupdt records to cache.
+      """
       pgrecs = self.pgmget("dlupdt", "lindex, enddate, endhour", "cindex = {}".format(cidx), self.PGOPT['emlerr'])
       cnt =  len(pgrecs['lindex']) if pgrecs else 0
       for i in range(cnt):
@@ -1524,6 +1967,19 @@ class PgUpdt(PgOPT, PgCMD):
 
    #  check if valid host to process update control
    def valid_control_host(self, cstr, hosts, logact):
+      """Verify that the current host is allowed to process the given update control.
+
+      The *hosts* field may be a plain hostname (must match) or ``!hostname``
+      (must NOT match).
+
+      Args:
+         cstr (str): Control identifier string for log messages.
+         hosts (str | None): Allowed or excluded hostname pattern from dcupdt.
+         logact (int): Log action bitmask for failure messages.
+
+      Returns:
+         bool: self.SUCCESS if the host is valid, self.FAILURE otherwise.
+      """
       host = self.get_host(1)
       if hosts:
          if re.search(host, hosts, re.I):
@@ -1535,6 +1991,18 @@ class PgUpdt(PgOPT, PgCMD):
 
    # reset updated data time
    def reset_data_time(self, qu, ddate, dhour, lidx):
+      """Update dcupdt.datatime and chktime to reflect the latest successfully archived data.
+
+      Tracks the earliest data time across all local files in PGOPT['DTIMES']
+      and writes the minimum value to the control record if it has advanced.
+
+      Args:
+         qu (str | None): Update frequency unit ('H', 'D', etc.) to determine
+            default hour when *dhour* is None.
+         ddate (str | None): Data date of the archived file.
+         dhour (int | None): Data hour of the archived file.
+         lidx (int): Local file index being updated.
+      """
       pgrec = self.PGOPT['UCNTL']
       record = {'chktime': int(time.time())}
       if ddate:
@@ -1552,6 +2020,22 @@ class PgUpdt(PgOPT, PgCMD):
 
    # adjust control time according to the control offset
    def adjust_control_time(self, cntltime, freq, unit, offset, curtime):
+      """Advance a control timestamp to the next scheduled run time.
+
+      Removes any configured offset, aligns the time to the frequency boundary
+      (e.g. truncates to the start of an hour or period), re-applies the offset,
+      then increments by *freq* until the result is strictly after *curtime*.
+
+      Args:
+         cntltime (str): Current dcupdt.cntltime (``YYYY-MM-DD HH:MM:SS``).
+         freq (list): Frequency array from get_control_time().
+         unit (str): Frequency unit character ('H', 'D', 'M', 'Y', 'W').
+         offset (str | None): Control offset string (e.g. '2H') or None.
+         curtime (str): Current wall-clock datetime string.
+
+      Returns:
+         str: Next scheduled control time (``YYYY-MM-DD HH:MM:SS``).
+      """
       if offset:
          ofreq = self.get_control_time(offset, "Control Offset")
          if ofreq:   # remove control offset
@@ -1579,7 +2063,12 @@ class PgUpdt(PgOPT, PgCMD):
       return cntltime
 
    #  reset control time
-   def reset_control_time(self):   
+   def reset_control_time(self):
+      """Compute and write the next dcupdt.cntltime after a completed (or failed) run.
+
+      If there were errors, the retry interval is used to schedule an earlier
+      retry provided it falls before the normal next run time.
+      """   
       pgrec = self.PGOPT['UCNTL']
       cstr = "{}-C{}".format(self.params['DS'], pgrec['cindex'])
       gmt = self.PGLOG['GMTZ']
@@ -1611,6 +2100,21 @@ class PgUpdt(PgOPT, PgCMD):
 
    # get array information of individual controlling time
    def get_control_time(self, val, type):
+      """Parse a time-interval string into a 7-element integer array.
+
+      Recognises Y (year), M (month), D (day), W (week, converted to days),
+      H (hour), N (minute), and S (second) suffixes.  Returns 0 for falsy or
+      '0' values.  Logs and returns None for unsupported fractional notation or
+      strings with no recognised units.
+
+      Args:
+         val (str | None): Interval string such as ``'6H'``, ``'1M'``, ``'2W3D'``.
+         type (str): Human-readable name for error messages.
+
+      Returns:
+         list[int] | int | None: 7-element list [Y,M,D,H,min,sec,frac], 0 for
+         empty input, or None on parse error.
+      """
       if not val or val == '0': return 0
       if re.search(r'/(\d+)$', val):
          return self.pglog("{}: '{}' NOT support Fraction".format(val, type), self.PGOPT['emlerr'])
@@ -1635,6 +2139,20 @@ class PgUpdt(PgOPT, PgCMD):
 
    #  get group index from given option string
    def get_group_index(self, option, edate, ehour, freq):
+      """Extract the dataset group index from a dsarch options string.
+
+      Looks for ``-GI <index>`` (literal or pattern) or ``-GN <group_name>``
+      in the options string.  Returns 0 if neither is found.
+
+      Args:
+         option (str): dsarch options string from dlupdt.options.
+         edate (str): End data date for pattern replacement.
+         ehour (int | None): End data hour.
+         freq (list): Frequency array for pattern replacement.
+
+      Returns:
+         int: Group index, or 0 if not specified.
+      """
       ms = re.search(r'-GI\s+(\S+)', option, re.I)
       if ms: return int(self.replace_pattern(ms.group(1), edate, ehour, freq))
       ms = re.search(r'-GN\s+(.*)$', option, re.I)


### PR DESCRIPTION
## Summary

- **`pg_updt.py`**: Added comprehensive Google-style docstrings to the `PgUpdt` class, `__init__`, and all 33 methods covering option codes, table hash mappings, SQL clause builders, temporal pattern replacement, remote/local file name resolution, update control caching, and download status checks
- **`dsupdt.py`**: Added docstrings to the `DsUpdt` class, `__init__`, and all 39 methods covering the full dataset update workflow (download → validate/convert → build → archive → clean); fixed an indentation mismatch in `read_parameters` caused by its non-standard 9-space method body indent
- **`dsupdt.usg`**: Improved prose clarity, grammar, and internal consistency throughout while strictly preserving the original plain-text format, numbered sections, aligned option tables, and `<<Content of...>>` example blocks

Key `dsupdt.usg` fixes include:
- Fixed `-(- UL|UnLockUpdate)` syntax typo in §3.3.7
- Removed misplaced `-(GZ|GMTZone)` from the Archive Files Info option syntax block (it is a Mode option)
- Standardized Mode option section headers for PB, AF, and CF actions
- Corrected `-SP` reference to `-DV` in the `-IF` input file format description
- Rewrote AF mode option descriptions for consistent active voice
- Clarified `-AW`, `-HU`, `-BP`, `-EH`, `-GP`, `-RF`, and `-WD` option descriptions

## Test plan

- [ ] Verify `python3 -c "import ast; ast.parse(open('src/rda_python_dsupdt/dsupdt.py').read())"` passes
- [ ] Verify `python3 -c "import ast; ast.parse(open('src/rda_python_dsupdt/pg_updt.py').read())"` passes
- [ ] Review docstrings in `pg_updt.py` and `dsupdt.py` for accuracy against the implementation
- [ ] Review `dsupdt.usg` improvements for correctness and consistent formatting

🤖 Generated with [Claude Code](https://claude.com/claude-code)